### PR TITLE
fix: set the basic auth for all requests

### DIFF
--- a/src/ManagementApi/Client.php
+++ b/src/ManagementApi/Client.php
@@ -68,7 +68,12 @@ class Client
             $headers['Content-Type'] = 'application/json';
         }
 
-        $response = $this->client->send(new Request($method, $endpoint, $headers, $body));
+        $response = $this->client->send(
+            new Request($method, $endpoint, $headers, $body),
+            [
+                'auth' => [$this->username, $this->password],
+            ]
+        );
 
         return json_decode($response->getBody(), true);
     }


### PR DESCRIPTION
Seems after the Guzzle v3 to Guzzle v6 we never set the auth back on, so its always been failing. 