### PR TITLE
Messages should be requeued using the 'ackmode' parameter

### DIFF
--- a/src/ManagementApi/Api/Queue.php
+++ b/src/ManagementApi/Api/Queue.php
@@ -132,6 +132,7 @@ class Queue extends AbstractApi
         $parameters = [
             'count' => $count,
             'requeue' => $requeue,
+            'ackmode' => $requeue ? 'ack_requeue_true' : 'ack_requeue_false',
             'encoding' => $encoding,
         ];
 


### PR DESCRIPTION
Starting with version 3.7.x of the rabbitmq-management plugin, the `ackmode` parameter is being used instead of the `requeue` one (discussed here: https://github.com/rabbitmq/rabbitmq-management/issues/521).

This patch uses both parameters so the library is compatible across rabbitmq-management versions.